### PR TITLE
chore: update relay and verification download urls to use relays 0.6.…

### DIFF
--- a/pkg/network/certbot.go
+++ b/pkg/network/certbot.go
@@ -191,7 +191,7 @@ func GetCertificates(currentUsername, domainName, nginxConfigFilePath string) bo
 			DefaultValueIndex: 0,
 			DefaultText:       "Do you want to remove or update your Certbot email?",
 			TextStyle:         &ThemeDefault.PrimaryStyle,
-			Options:           []string{"yes", "no"},
+			Options:           []string{"no", "yes"},
 			OptionsStyle:      &ThemeDefault.SuccessMessageStyle,
 			SuffixStyle:       &ThemeDefault.SecondaryStyle,
 			Delimiter:         ": ",

--- a/pkg/relays/khatru29/constants.go
+++ b/pkg/relays/khatru29/constants.go
@@ -1,6 +1,6 @@
 package khatru29
 
-const DownloadURL = "https://github.com/nodetec/relays/releases/download/v0.5.0/relay29-0.5.1-khatru29-x86_64-linux-gnu.tar.gz"
+const DownloadURL = "https://github.com/nodetec/relays/releases/download/v0.6.0/relay29-0.5.1-khatru29-x86_64-linux-gnu.tar.gz"
 const BinaryName = "khatru29"
 const DataDirPath = "/var/lib/khatru29"
 const DatabaseFilePath = "/var/lib/khatru29/db/data.mdb"

--- a/pkg/relays/khatru_pyramid/constants.go
+++ b/pkg/relays/khatru_pyramid/constants.go
@@ -1,6 +1,6 @@
 package khatru_pyramid
 
-const DownloadURL = "https://github.com/nodetec/relays/releases/download/v0.5.0/khatru-pyramid-0.2.2-x86_64-linux-gnu.tar.gz"
+const DownloadURL = "https://github.com/nodetec/relays/releases/download/v0.6.0/khatru-pyramid-0.2.2-x86_64-linux-gnu.tar.gz"
 const BinaryName = "khatru-pyramid"
 const DataDirPath = "/var/lib/khatru-pyramid"
 const DatabaseFilePath = "/var/lib/khatru-pyramid/db/data.mdb"

--- a/pkg/relays/nostr_rs_relay/constants.go
+++ b/pkg/relays/nostr_rs_relay/constants.go
@@ -3,7 +3,7 @@ package nostr_rs_relay
 const GitRepoBranch = "0.9.0"
 const GitRepoURL = "https://github.com/scsibug/nostr-rs-relay"
 const GitRepoTmpDirPath = "/tmp/nostr-rs-relay"
-const DownloadURL = "https://github.com/nodetec/relays/releases/download/v0.5.0/nostr-rs-relay-0.9.0-x86_64-linux-gnu.tar.gz"
+const DownloadURL = "https://github.com/nodetec/relays/releases/download/v0.6.0/nostr-rs-relay-0.9.0-x86_64-linux-gnu.tar.gz"
 const BinaryName = "nostr-rs-relay"
 const DataDirPath = "/var/lib/nostr-rs-relay"
 const DatabaseFilePath = "/var/lib/nostr-rs-relay/db/nostr.db"

--- a/pkg/relays/strfry/constants.go
+++ b/pkg/relays/strfry/constants.go
@@ -3,7 +3,7 @@ package strfry
 const GitRepoBranch = "1.0.4"
 const GitRepoURL = "https://github.com/hoytech/strfry.git"
 const GitRepoTmpDirPath = "/tmp/strfry"
-const DownloadURL = "https://github.com/nodetec/relays/releases/download/v0.5.0/strfry-1.0.4-x86_64-linux-gnu.tar.gz"
+const DownloadURL = "https://github.com/nodetec/relays/releases/download/v0.6.0/strfry-1.0.4-x86_64-linux-gnu.tar.gz"
 const BinaryName = "strfry"
 const BinaryVersion = "1.0.4"
 const DataDirPath = "/var/lib/strfry"

--- a/pkg/relays/wot_relay/constants.go
+++ b/pkg/relays/wot_relay/constants.go
@@ -3,7 +3,7 @@ package wot_relay
 const GitRepoBranch = "v0.1.16"
 const GitRepoURL = "https://github.com/bitvora/wot-relay.git"
 const GitRepoTmpDirPath = "/tmp/wot-relay"
-const DownloadURL = "https://github.com/nodetec/relays/releases/download/v0.5.0/wot-relay-0.1.16-x86_64-linux-gnu.tar.gz"
+const DownloadURL = "https://github.com/nodetec/relays/releases/download/v0.6.0/wot-relay-0.1.16-x86_64-linux-gnu.tar.gz"
 const BinaryName = "wot-relay"
 const DataDirPath = "/var/lib/wot-relay"
 const ConfigDirPath = "/etc/wot-relay"

--- a/pkg/verification/constants.go
+++ b/pkg/verification/constants.go
@@ -1,6 +1,6 @@
 package verification
 
 const NodeTecKeybasePGPKeyURL = "https://keybase.io/nodetec/pgp_keys.asc"
-const RelaysManifestFileURL = "https://github.com/nodetec/relays/releases/download/v0.5.0/relays-0.5.0-manifest.sha512sum"
-const RelaysManifestSigFileURL = "https://github.com/nodetec/relays/releases/download/v0.5.0/relays-0.5.0-manifest.sha512sum.asc"
+const RelaysManifestFileURL = "https://github.com/nodetec/relays/releases/download/v0.6.0/relays-0.6.0-manifest.sha512sum"
+const RelaysManifestSigFileURL = "https://github.com/nodetec/relays/releases/download/v0.6.0/relays-0.6.0-manifest.sha512sum.asc"
 const NodeTecSigningSubkeyFingerprint = "252F57B9DCD920EBF14E6151A8841CC4D10CC288"


### PR DESCRIPTION
…0 and change the default option to be no when asking if the user wants to remove or update their certbot email

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the order of interactive prompt options in certificate configuration to better align with expected user selection behavior and defaults.

* **Chores**
  * Updated relay component package versions from v0.5.0 to v0.6.0 across all supported relay implementations.
  * Updated verification manifest and corresponding signature file references from v0.5.0 to v0.6.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->